### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Install and test AVA
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/donnnq/ava/security/code-scanning/1](https://github.com/donnnq/ava/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for all jobs. Based on the workflow's tasks, the `contents: read` permission is sufficient, as the jobs only need to read the repository's contents (e.g., for checking out code and running tests). No write permissions are necessary.

The `permissions` block will be added at the top level of the workflow, immediately after the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
